### PR TITLE
Move some variable

### DIFF
--- a/pycocotools/pycocotools/coco.py
+++ b/pycocotools/pycocotools/coco.py
@@ -78,8 +78,6 @@ class COCO:
         self.dataset, self.anns, self.cats, self.imgs = dict(), dict(), dict(
         ), dict()
         self.imgToAnns, self.catToImgs = defaultdict(list), defaultdict(list)
-        self.img_ann_map = self.imgToAnns
-        self.cat_img_map = self.catToImgs
         if annotation_file is not None:
             print('loading annotations into memory...')
             tic = time.time()
@@ -92,6 +90,8 @@ class COCO:
             print('Done (t={:0.2f}s)'.format(time.time() - tic))
             self.dataset = dataset
             self.createIndex()
+        self.img_ann_map = self.imgToAnns
+        self.cat_img_map = self.catToImgs
 
     def createIndex(self):
         # create index
@@ -123,8 +123,6 @@ class COCO:
         self.catToImgs = catToImgs
         self.imgs = imgs
         self.cats = cats
-        self.img_ann_map = self.imgToAnns
-        self.cat_img_map = self.catToImgs
 
     def info(self):
         """

--- a/pycocotools/setup.py
+++ b/pycocotools/setup.py
@@ -24,5 +24,5 @@ setup(name='mmpycocotools',
       install_requires=[
           'setuptools>=18.0', 'cython>=0.27.3', 'matplotlib>=2.1.0'
       ],
-      version='12.0.2',
+      version='12.0.3',
       ext_modules=ext_modules)


### PR DESCRIPTION
This PR removed `self.img_ann_map` and `self.cat_img_map` from `self.createIndex()`. So that when a class inherits from `COCO`, user only needs to take care of `self.catToImgs` and `self.imgToAnns`. 